### PR TITLE
Support plot functions that take multiple studies as an argument

### DIFF
--- a/studies.py
+++ b/studies.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -27,8 +26,8 @@ def objective_single_dynamic(trial: optuna.Trial) -> float:
         return -((trial.suggest_float("x2", -10, 0) + 5) ** 2)
 
 
-def create_single_objective_studies() -> Dict[str, StudiesType]:
-    studies: Dict[str, StudiesType] = {}
+def create_single_objective_studies() -> List[Tuple[str, StudiesType]]:
+    studies: List[Tuple[str, StudiesType]] = []
     storage = optuna.storages.InMemoryStorage()
 
     # Single-objective study
@@ -38,7 +37,7 @@ def create_single_objective_studies() -> Dict[str, StudiesType]:
     )
 
     study.optimize(objective_single, n_trials=50)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     # Single-objective study with dynamic search space
     study = optuna.create_study(
@@ -48,15 +47,15 @@ def create_single_objective_studies() -> Dict[str, StudiesType]:
     )
 
     study.optimize(objective_single_dynamic, n_trials=50)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     # No trials single-objective study
     optuna.create_study(study_name="A single objective study that has no trials", storage=storage)
     return studies
 
 
-def create_multiple_single_objective_studies() -> Dict[str, StudiesType]:
-    studies: Dict[str, StudiesType] = {}
+def create_multiple_single_objective_studies() -> List[Tuple[str, StudiesType]]:
+    studies: List[Tuple[str, StudiesType]] = []
     storage = optuna.storages.InMemoryStorage()
 
     # Single-objective study
@@ -69,7 +68,7 @@ def create_multiple_single_objective_studies() -> Dict[str, StudiesType]:
         study.optimize(objective_single, n_trials=50)
         _static.append(study)
     title = "Two single objective studies with 2-dimensional static search space"
-    studies[title] = _static
+    studies.append((title, _static))
 
     # Single-objective study with dynamic search space
     _dynamic: List[Study] = []
@@ -82,13 +81,13 @@ def create_multiple_single_objective_studies() -> Dict[str, StudiesType]:
         study.optimize(objective_single_dynamic, n_trials=50)
         _dynamic.append(study)
     title = "Two single objective studies with 3-dimensional dynamic search space"
-    studies[title] = _dynamic
+    studies.append((title, _dynamic))
 
     return studies
 
 
-def create_multi_objective_studies() -> Dict[str, StudiesType]:
-    studies: Dict[str, StudiesType] = {}
+def create_multi_objective_studies() -> List[Tuple[str, StudiesType]]:
+    studies: List[Tuple[str, StudiesType]] = []
     storage = optuna.storages.InMemoryStorage()
 
     # Multi-objective study
@@ -105,7 +104,7 @@ def create_multi_objective_studies() -> Dict[str, StudiesType]:
         directions=["minimize", "minimize"],
     )
     study.optimize(objective_multi, n_trials=50)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     # Multi-objective study with dynamic search space
     study = optuna.create_study(
@@ -130,13 +129,13 @@ def create_multi_objective_studies() -> Dict[str, StudiesType]:
             return v0, v1
 
     study.optimize(objective_multi_dynamic, n_trials=50)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     return studies
 
 
-def create_intermediate_value_studies() -> Dict[str, StudiesType]:
-    studies: Dict[str, StudiesType] = {}
+def create_intermediate_value_studies() -> List[Tuple[str, StudiesType]]:
+    studies: List[Tuple[str, StudiesType]] = []
     storage = optuna.storages.InMemoryStorage()
 
     def objective_simple(trial: optuna.Trial, report_intermediate_values: bool) -> float:
@@ -164,27 +163,27 @@ def create_intermediate_value_studies() -> Dict[str, StudiesType]:
 
     study = optuna.create_study(study_name="Study with 1 trial", storage=storage)
     study.optimize(lambda t: objective_simple(t, True), n_trials=1)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     study = optuna.create_study(
         study_name="Study that is pruned after 'inf', '-inf', or 'nan'", storage=storage
     )
     study.optimize(objective_single_inf_report, n_trials=50)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     study = optuna.create_study(
         study_name="Study with only 1 trial that has no intermediate value",
         storage=storage,
     )
     study.optimize(lambda t: objective_simple(t, False), n_trials=1)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     study = optuna.create_study(study_name="Study that has only failed trials", storage=storage)
     study.optimize(fail_objective, n_trials=1, catch=(ValueError,))
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
 
     study = optuna.create_study(study_name="Study that has no trials", storage=storage)
-    studies[study.study_name] = study
+    studies.append((study.study_name, study))
     return studies
 
 

--- a/templates/plot_results.html
+++ b/templates/plot_results.html
@@ -34,8 +34,8 @@
 <body>
 <div class="wrapper">
     <h1>{{ funcname }}</h1>
-    {% for study, plotly_file, matplotlib_file in plot_files %}
-    <h2>{{ study.study_name }}</h2>
+    {% for title, plotly_file, matplotlib_file in plot_files %}
+    <h2>{{ title }}</h2>
     <div class="plot-wrapper">
         {% if plotly_file %}
         <img class="plot" src="{{ plotly_file }}">


### PR DESCRIPTION
## Motivation

`plot_optimization_history` and `plot_edf` accept a list of studies as the `study` argument, but the current test cases do not cover it.
This PR adds such test cases.

## Changes

In this PR, I tried to keep the structure of this software. The actual changes are as follows:

- Defined `StudiesType = Union[Study, Sequence[Study]]`
- Assumed that plot functions accept `studies: StudyType`
- Applied a wrapper to reject `Sequence[Study]` if actual plot functions do not accept it
- Changed return type of study creation functions from `List[Study]` to `Dict[str, StudyType]`. The key of the dictionary is a figure title. Originally, `Study.study_name` is used as figure titles, but the legends of multi-study plots will be too wide.
- Added `create_multiple_single_objective_studies`

### Screenshots

<img width="596" alt="image" src="https://user-images.githubusercontent.com/3255979/177481244-822d7e6c-89ba-439e-bf30-77aa3e000e9a.png">
<img width="583" alt="image" src="https://user-images.githubusercontent.com/3255979/177481289-74747673-2702-4a50-8ef2-08f1cb5ea1ec.png">
