### PR TITLE
Trigger gh-pages action weekly

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 * * *" # min(0-59) time(0-23) date(1-31) month(1-12) day(0-6)
+    - cron: "0 0 * * 0" # min(0-59) time(0-23) date(1-31) month(1-12) day(0-6)
 jobs:
   pull:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, `gh-pages` action is triggered every day. So the size of git repository seems to be increasing rapidly. In this PR, I proposed to reduce the interval to once a week.