### PR TITLE
Set `ref` of `actions/checkout` ref to PR head.

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: actions/setup-python@v4
       with:
@@ -32,7 +34,6 @@ jobs:
     - name: Install Optuna
       run: |
         pip install -U pip
-        pip install --progress-bar off .
         pip install git+https://github.com/optuna/optuna.git
     - name: Install Optuna visual regression
       run: |


### PR DESCRIPTION
## Motivation

The `netlify.yml` CI job of #8 checked out the `main` of the `optuna/optuna-visualization-regression-tests` instead of the head of PR. According to the [GitHub reference](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows), it was expected behavior since `GITHUB_SHA` and `GITHUB_REF` of `pull_request_target` are different from those of `pull_request`.

| event | `GITHUB_SHA` | `GITHUB_REF` |
| --- | --- | --- |
| [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) | Last merge commit on the `GITHUB_REF` branch | PR merge branch `refs/pull/:prNumber/merge` |
| [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) | Last commit on the PR base branch | PR base branch |

## Change

- Set `ref` of `actions/checkout` to `github.event.pull_request.head.sha`
  - The variable can be seen in https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- Remove unused `pip install command`