### PR TITLE
Support terminator improvement plots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ kaleido
 jinja2
 scikit-learn
 optuna-fast-fanova
+lightgbm
+botorch
 
 torch
 torchvision


### PR DESCRIPTION
Added support for `plot_terminator_improvement()` functions (refs https://github.com/optuna/optuna/pull/4701).

Please note that there is a bug that a segmentation fault is raised during execution on macOS with M1 Pro chip.
I'm not sure why but I prepared a minimal reproducible example below:
https://gist.github.com/c-bata/3a3eb5a4f8e46ba4726462979d92c466