### PR TITLE
Update action/cache

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
           pip install optuna/
       - name: Cache kurobako CLI
         id: cache-torch-dataset
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./FashionMNIST
           key: fasion-mnist


### PR DESCRIPTION
## Motivation

> The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible. We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).

Ref: https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

## Changes

Optuna uses v3 and v4's diff seems unimportant, so I suggest using v4.

- https://github.com/actions/cache/releases/tag/v4.0.0 (node version update).
- Note that save-alwasy is removed in https://github.com/actions/cache/releases/tag/v4.1.0
